### PR TITLE
Add clock comparison demo and fix GitHub Pages base

### DIFF
--- a/README_DEPLOY.md
+++ b/README_DEPLOY.md
@@ -3,7 +3,7 @@
 This project uses Vite + React. It is configured to deploy automatically to GitHub Pages.
 
 ## How it works
-- `vite.config.ts` sets `base` to `/relativity-visualizer/` so assets resolve correctly when hosted at `https://<username>.github.io/relativity-visualizer/`.
+- `vite.config.ts` uses a relative `base` (`./`) so assets resolve correctly when hosted at `https://<username>.github.io/relativity-visualizer/` or any other path.
 - GitHub Actions workflow `.github/workflows/deploy.yml` builds the site and publishes the `dist/` folder to the `gh-pages` branch on every push to `main` (or `master`).
 
 ## One-time repo settings
@@ -22,4 +22,4 @@ This project uses Vite + React. It is configured to deploy automatically to GitH
 ## Live URL
 `https://<your-username>.github.io/relativity-visualizer/`
 
-If your repository name changes, update `base` in `vite.config.ts` accordingly.
+If your repository name changes, `base` does not need adjustments because it is relative.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,12 +3,13 @@ import EuclideanTriangle from './components/EuclideanTriangle';
 import MinkowskiDiagram from './components/MinkowskiDiagram';
 import CurvedSpace from './components/CurvedSpace';
 import Labs from './components/Labs';
+import ClockComparison from './components/ClockComparison';
 
 const THEMES = ['night', 'synthwave', 'business'] as const;
 type Theme = typeof THEMES[number];
 
 export default function App() {
-    const [tab, setTab] = useState<'euclid' | 'minkowski' | 'curved' | 'labs'>('minkowski');
+    const [tab, setTab] = useState<'euclid' | 'minkowski' | 'curved' | 'clock' | 'labs'>('minkowski');
     const [theme, setTheme] = useState<Theme>('night');
 
     useEffect(() => {
@@ -62,6 +63,11 @@ export default function App() {
                         Curved Space (GR)
                     </a>
                     <a role="tab"
+                       className={`tab ${tab === 'clock' ? 'tab-active' : ''}`}
+                       onClick={() => setTab('clock')}>
+                        Clock Comparison
+                    </a>
+                    <a role="tab"
                        className={`tab ${tab === 'labs' ? 'tab-active' : ''}`}
                        onClick={() => setTab('labs')}>
                         Labs
@@ -71,6 +77,7 @@ export default function App() {
                 {tab === 'minkowski' && <MinkowskiDiagram />}
                 {tab === 'euclid' && <EuclideanTriangle />}
                 {tab === 'curved' && <CurvedSpace />}
+                {tab === 'clock' && <ClockComparison />}
                 {tab === 'labs' && <Labs />}
             </div>
 

--- a/src/components/ClockComparison.tsx
+++ b/src/components/ClockComparison.tsx
@@ -1,0 +1,41 @@
+import { useEffect, useRef, useState } from "react";
+
+/**
+ * Rate advantage of the GPS satellite clock over an Earth-surface clock.
+ * 38 μs/day ≈ 4.4e-10 fractional difference.
+ */
+const RATE_DIFF = 38e-6 / 86400; // per second
+
+export default function ClockComparison() {
+  const [earthTime, setEarthTime] = useState(0);
+  const [satTime, setSatTime] = useState(0);
+  const timerRef = useRef<NodeJS.Timer>();
+
+  useEffect(() => {
+    const start = performance.now();
+    timerRef.current = setInterval(() => {
+      const now = performance.now();
+      const elapsed = (now - start) / 1000; // seconds
+      setEarthTime(elapsed);
+      setSatTime(elapsed * (1 + RATE_DIFF));
+    }, 50);
+    return () => clearInterval(timerRef.current);
+  }, []);
+
+  const diffMicro = (satTime - earthTime) * 1e6;
+
+  return (
+    <div className="card bg-base-100 shadow">
+      <div className="card-body">
+        <h2 className="card-title">Clock Comparison (GR)</h2>
+        <div>Earth clock: {earthTime.toFixed(6)} s</div>
+        <div>GPS clock: {satTime.toFixed(6)} s</div>
+        <div className="font-mono">Offset: {diffMicro.toFixed(3)} µs</div>
+        <p className="text-sm opacity-70">
+          The GPS satellite's clock runs faster by about 38 μs per day due to
+          gravitational and velocity effects predicted by General Relativity.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,8 @@ import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  base: '/relativity-visualizer/',
+  // Use a relative base so the site works on GitHub Pages and local file URLs
+  base: './',
   plugins: [react()],
   resolve: {
     dedupe: ['react', 'react-dom'],


### PR DESCRIPTION
## Summary
- add interactive ClockComparison component highlighting GPS vs Earth time dilation
- expose demo via new Clock Comparison tab before Labs
- switch Vite base to relative path so site loads on GitHub Pages

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be030f81c4832f911ceb1da2f38bee